### PR TITLE
Hugo 0.141.0 deprecation fixes

### DIFF
--- a/.github/workflows/seo.yml
+++ b/.github/workflows/seo.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.6.0
         with:
+          hugo-version: "0.111.3"
           extended: true
 
       - name: Serve site
@@ -86,6 +87,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2.6.0
         with:
+          hugo-version: "0.111.3"
           extended: true
 
       - name: Serve site

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -4,10 +4,12 @@ title = "[Beta] 3mdeb Sp. z o.o. — Embedded Firmware development consultancy"
 theme = ["3mdeb"]
 # Default time zone for time stamps; use any valid tz database name: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 timeZone = "UTC"
-# post pagination
-paginate = "6" # see https://gohugo.io/extras/pagination/
 # post excerpt
 summaryLength = "10" # see https://gohugo.io/content-management/excerpts/
+
+# post pagination
+[pagination]
+  pagerSize = 6 # see https://gohugo.io/extras/pagination/
 
 [params]
 # google analytics

--- a/content/events.md
+++ b/content/events.md
@@ -209,8 +209,8 @@ all_events:
             Topic: **Dealing with UEFI Secure Boot support using Yocto Project**<br>
             Presenters: **Tomasz Żyjewski**
 
-            * [**Direct link**](https://summit.yoctoproject.org/yocto-project-summit-2023-11/talk/HGTEGC/)
-            * [**Slides**](https://summit.yoctoproject.org/media/yocto-project-summit-2023-11/submissions/HGTEGC/resources/presentation_zq25ldK.pdf)
+            * [**Direct link**](https://web.archive.org/web/20240812072336/https://summit.yoctoproject.org/yocto-project-summit-2023-11/talk/HGTEGC/)
+            * [**Slides**](http://web.archive.org/web/20240517110258/https://summit.yoctoproject.org/media/yocto-project-summit-2023-11/submissions/HGTEGC/resources/presentation_zq25ldK.pdf)
 
         - date: "30.11.2023"
           image: ""
@@ -220,8 +220,8 @@ all_events:
             Topic: **FIDO Device Onboarding: Late-binding Provisioning & Tales from the Trenches of Bleeding Edge Tech**  <br>
             Presenters: **Tymek Burak**
 
-            * [**Direct link**](https://summit.yoctoproject.org/yocto-project-summit-2023-11/talk/KXCZYK/)
-            * [**Slides**](https://summit.yoctoproject.org/media/yocto-project-summit-2023-11/submissions/KXCZYK/resources/FIDO_Device_Onboarding_YoctoSu_C14fiKE.pdf)
+            * [**Direct link**](http://web.archive.org/web/20240812063556/https://summit.yoctoproject.org/yocto-project-summit-2023-11/talk/KXCZYK/)
+            * [**Slides**](http://web.archive.org/web/20240517110229/https://summit.yoctoproject.org/media/yocto-project-summit-2023-11/submissions/KXCZYK/resources/FIDO_Device_Onboarding_YoctoSu_C14fiKE.pdf)
 
     - title: "Qubes OS **Summit 2023**"
       status: ""
@@ -308,7 +308,7 @@ all_events:
             Presenters: **Tomasz Żyjewski**
 
             * [**Direct link**](https://www.yoctoproject.org/yocto-project-at-embedded-open-source-summit-2023/)
-            * [**Slides**](https://summit.yoctoproject.org/media/devday-at-eoss-2023/submissions/XZYTCW/resources/presentation_v1.1_R3aJg51.pdf)
+            * [**Slides**](http://web.archive.org/web/20230811182550/https://summit.yoctoproject.org/media/devday-at-eoss-2023/submissions/XZYTCW/resources/presentation_v1.1_R3aJg51.pdf)
 
         - date: "26.06.2023"
           image: ""
@@ -319,7 +319,7 @@ all_events:
             Presenters: **Tomasz Żyjewski, Maciej Pijanowski**
 
             * [**Direct link**](https://www.yoctoproject.org/yocto-project-at-embedded-open-source-summit-2023/)
-            * [**Slides**](https://summit.yoctoproject.org/media/devday-at-eoss-2023/submissions/JPX8ND/resources/Unveiling_OpenBMC__Exploring_features_a_xkqHpmo.pdf)
+            * [**Slides**](http://web.archive.org/web/20230812234006/https://summit.yoctoproject.org/media/devday-at-eoss-2023/submissions/JPX8ND/resources/Unveiling_OpenBMC__Exploring_features_a_xkqHpmo.pdf)
 
     - title: "Xen Developer **& Design Summit**"
       status: ""
@@ -442,7 +442,7 @@ all_events:
             Presenters: **Tomasz Żyjewski**
 
             * [**Direct link**](https://pretalx.com/yocto-project-summit-2022-11/talk/KJDAFF/)
-            * [**Slides**](https://summit.yoctoproject.org/media/yocto-project-summit-2022-11/submissions/KJDAFF/resources/slides_v1.1_WFR8xEf.pdf)
+            * [**Slides**](http://web.archive.org/web/20240701121128/https://summit.yoctoproject.org/media/yocto-project-summit-2022-11/submissions/KJDAFF/resources/slides_v1.1_WFR8xEf.pdf)
 
     - title: "Open Source **Firmware Conference**"
       status: ""
@@ -609,7 +609,6 @@ all_events:
 
             * [**Direct link**](https://archive.fosdem.org/2022/schedule/event/ost2/)
             * [**Slides**](https://shop.3mdeb.com/wp-content/uploads/2022/08/OST2_-A-new-way-to-grow-security-talent-for-open-source-projects.pdf)
-            * [**Video**](https://ftp.heanet.ie/mirrors/fosdem-video/2022/D.firmware/ost2.mp4)
 
         - date: "06.02.2022"
           image: ""

--- a/scripts/local-preview.sh
+++ b/scripts/local-preview.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-docker run --rm -it -v $PWD:/src -p 1313:1313 -u $(id -u) klakegg/hugo:0.111.3-ext-alpine serve -b $1
+BASE_URL=${1:-http://localhost:1313}
+docker run --rm -it -v $PWD:/src -p 1313:1313 -u $(id -u) klakegg/hugo:0.111.3-ext-alpine serve -b $BASE_URL

--- a/themes/3mdeb/layouts/partials/essentials/style.html
+++ b/themes/3mdeb/layouts/partials/essentials/style.html
@@ -40,7 +40,7 @@
 
 <!-- Purge CSS in Production -->
 {{ if and hugo.IsProduction site.Params.purge_css }}
-  {{ $styles = $styles | css.PostCSS | fingerprint "sha256" | minify }}
+  {{ $styles = $styles | resources.PostCSS | fingerprint "sha256" | minify }}
   {{ $styles = $styles | resources.PostProcess }}
 {{ end }}
 

--- a/themes/3mdeb/layouts/partials/essentials/style.html
+++ b/themes/3mdeb/layouts/partials/essentials/style.html
@@ -40,7 +40,7 @@
 
 <!-- Purge CSS in Production -->
 {{ if and hugo.IsProduction site.Params.purge_css }}
-  {{ $styles = $styles | resources.PostCSS | fingerprint "sha256" | minify }}
+  {{ $styles = $styles | css.PostCSS | fingerprint "sha256" | minify }}
   {{ $styles = $styles | resources.PostProcess }}
 {{ end }}
 


### PR DESCRIPTION
What has been fixed:
* `paginate` deprecated parameter - [commit](https://github.com/3mdeb/3mdeb-website/pull/178/commits/43472650fba15a14e9f44b806bf97b12620ced6a)

What needs to be fixed:
```
ERROR deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.141.0. Implement taxonomy 'social' or use .Site.Params.Social instead.
ERROR deprecated: .Site.Authors was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.141.0. Implement taxonomy 'authors' or use .Site.Params.Author instead.
```

My local hugo version :
```
hugo v0.140.2-aae02ca612a02e085c08366a9c9279f4abb39d94+extended linux/amd64 BuildDate=2024-12-30T15:01:53Z VendorInfo=snap:0.140.2
```

Attempts so far:
* our code doesn't use `.site.Social/Authors` or I'm unaware of some magic imports, so it is not so easy as suggested to use `.Site.Params..`
* Author deprecation error:
  - `authors` is used only in the `themes/3mdeb/layouts/author/single.html` (grepped)
  - tried taxonomies - no success:
    * added taxonomies in the `config.toml` and/or `config/_default/config.toml` as in the [example](https://gohugo.io/content-management/taxonomies/#example-adding-a-custom-taxonomy-named-series)
    * changed author param in the `single.html` to use taxonomies like in the example of `partials/widgets/tag.html`
  - tried removing the author section - no success
  - tried removing `single.html` and the `authors` directory - build still fails, which suggests that some indirect template/partial is used? Can be related to `module.toml` and some themes listed there...
* Socials:
  - tried the same thing as above
  - tried with workaround `social = true` in the params from `config.toml`
  - tried changing parameter names in the `params.toml` to other than `social`. Then changed the corresponding files to use the new parameter names. The corresponding files:
    * `themes/3mdeb/layouts/partials/essentials/header.html`
    * `themes/3mdeb/layouts/partials/essentials/footer.html
    * `themes/3mdeb/layouts/_default/contact.html`